### PR TITLE
Update trainer.py: do not apply softmax inside train_and_valid and test functions

### DIFF
--- a/trademaster/trainers/portfolio_management/trainer.py
+++ b/trademaster/trainers/portfolio_management/trainer.py
@@ -111,7 +111,6 @@ class PortfolioManagementTrainer(Trainer):
             episode_reward_sum = 0
             while True:
                 action = self.trainer.compute_single_action(state)
-                action=np.exp(action)/np.sum(np.exp(action))
                 state, reward, done, information = self.valid_environment.step(action)
                 episode_reward_sum += reward
                 if done:
@@ -141,7 +140,6 @@ class PortfolioManagementTrainer(Trainer):
         episode_reward_sum = 0
         while True:
             action = self.trainer.compute_single_action(state)
-            action=np.exp(action)/np.sum(np.exp(action))
 
             state, reward, done, sharpe = self.test_environment.step(action)
             episode_reward_sum += reward


### PR DESCRIPTION
Doing `action=np.exp(action)/np.sum(np.exp(action))` in valid and test transform the weights to a smaller interval than [0,1]. For example, with 3 stocks, each one will has weight in the interval [0.21, 0.58]. It's not necessary (in fact it's wrong) to make this assignment here since the softmax function is already applied inside step function.