### PR TITLE
Add optional Adanos market sentiment module for FinAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ TradeMaster provides many visualization toolkits for a systematic evaluation of 
 ## Publications
 [A multimodal foundation agent for financial trading: Tool-augmented, diversified, and generalist](https://personal.ntu.edu.sg/boan/papers/KDD24_FinAgent.pdf) *(KDD 2024)*
 
+### Optional Adanos market sentiment for FinAgent
+
+TradeMaster's `finagent` stack already accepts an optional `sentiment_path`. This PR adds an alternative downloader path for [Adanos Market Sentiment API](https://api.adanos.org/docs/) so FinAgent experiments can enrich stocks with cross-source market sentiment from Reddit, X, News, and Polymarket without changing the default FMP-based setup.
+
+- Config example: `configs/finagent/downloader/tools/adanos_sentiment_exp.py`
+- Auth: set `ADANOS_API_KEY`
+- Output: daily CSV files that can be processed into the existing `sentiment_path` parquet flow
+- Scope: fully optional; existing FMP sentiment configs continue to work unchanged
+
 [MacroHFT: Memory augmented context-aware reinforcement learning on high frequency trading](https://personal.ntu.edu.sg/boan/papers/KDD24_MacroHFT.pdf) *(KDD 2024)*
 
 [Reinforcement learning with maskable stock representation for portfolio management in customizable stock pools](https://personal.ntu.edu.sg/boan/papers/WWW24_EarnMore.pdf) *(WWW 2024)*

--- a/configs/finagent/downloader/tools/adanos_sentiment_exp.py
+++ b/configs/finagent/downloader/tools/adanos_sentiment_exp.py
@@ -1,0 +1,20 @@
+root = None
+workdir = "workdir"
+tag = "adanos_sentiment_exp"
+batch_size = 1
+
+downloader = dict(
+    type = "AdanosSentimentDownloader",
+    root = root,
+    token = None,
+    base_url = "https://api.adanos.org",
+    start_date = "2023-01-01",
+    end_date = "2024-01-01",
+    delay = 0.5,
+    days = 30,
+    sources = ["reddit", "x", "news", "polymarket"],
+    timeout = 30,
+    stocks_path = "configs/_stock_list_/exp_stocks.txt",
+    workdir = workdir,
+    tag = tag,
+)

--- a/finagent/data/dataset.py
+++ b/finagent/data/dataset.py
@@ -6,6 +6,43 @@ import pandas as pd
 pd.set_option('display.max_columns', 100000)
 pd.set_option('display.max_rows', 100000)
 
+STOCKTWITS_SENTIMENT_COLUMNS = [
+    "timestamp",
+    "stocktwits_posts",
+    "stocktwits_comments",
+    "stocktwits_likes",
+    "stocktwits_impressions",
+    "stocktwits_sentiment",
+]
+
+ADANOS_SENTIMENT_COLUMNS = [
+    "timestamp",
+    "adanos_source",
+    "adanos_buzz_score",
+    "adanos_mentions",
+    "adanos_sentiment_score",
+    "adanos_bullish_pct",
+    "adanos_bearish_pct",
+    "adanos_trend",
+    "adanos_latest_buzz_score",
+    "adanos_latest_sentiment_score",
+]
+
+
+def normalize_sentiment_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize supported social sentiment parquet schemas."""
+    columns = set(df.columns)
+
+    if set(STOCKTWITS_SENTIMENT_COLUMNS).issubset(columns):
+        return df[STOCKTWITS_SENTIMENT_COLUMNS].copy()
+
+    if set(ADANOS_SENTIMENT_COLUMNS).issubset(columns):
+        return df[ADANOS_SENTIMENT_COLUMNS].copy()
+
+    raise KeyError(
+        "Unsupported sentiment schema. Expected Stocktwits/FMP columns or Adanos sentiment columns."
+    )
+
 @DATASET.register_module(force=True)
 class Dataset(BaseDataset):
     def __init__(self,
@@ -153,12 +190,7 @@ class Dataset(BaseDataset):
             df = df.sort_values(by="timestamp")
             df = df.reset_index(drop=True)
 
-            df = df[["timestamp",
-                     "stocktwits_posts",
-                     "stocktwits_comments",
-                     "stocktwits_likes",
-                     "stocktwits_impressions",
-                     "stocktwits_sentiment"]]
+            df = normalize_sentiment_dataframe(df)
 
             sentiments[asset] = df
 

--- a/finagent/downloader/__init__.py
+++ b/finagent/downloader/__init__.py
@@ -8,6 +8,7 @@ from .prices import YahooFinanceDayPriceDownloader
 from .prices import FMPDayPriceDownloader
 from .tools import RapidAPIDownloader
 from .tools import FMPSentimentDownloader
+from .tools import AdanosSentimentDownloader
 
 __all__ = [
     "YahooFinanceNewsDownloader",
@@ -19,5 +20,6 @@ __all__ = [
     "FMPForexNewsDownloader",
     "FMPCryptoNewsDownloader",
     "RapidAPIDownloader",
-    "FMPSentimentDownloader"
+    "FMPSentimentDownloader",
+    "AdanosSentimentDownloader",
 ]

--- a/finagent/downloader/tools/__init__.py
+++ b/finagent/downloader/tools/__init__.py
@@ -1,3 +1,4 @@
 from .rapidapi_downloader import RapidAPIDownloader
 from .fmp_sentiment_downloader import FMPSentimentDownloader
 from .fmp_economic_downloader import FMPEconomicDownloader
+from .adanos_sentiment_downloader import AdanosSentimentDownloader

--- a/finagent/downloader/tools/adanos_sentiment_downloader.py
+++ b/finagent/downloader/tools/adanos_sentiment_downloader.py
@@ -1,0 +1,221 @@
+import os
+import time
+from typing import Any
+
+import pandas as pd
+import requests
+from dotenv import load_dotenv
+
+from finagent.downloader.custom import Downloader
+from finagent.registry import DOWNLOADER
+
+load_dotenv(verbose=True)
+
+ADANOS_SOURCES = ("reddit", "x", "news", "polymarket")
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None or value == "":
+            return default
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def build_adanos_sentiment_frame(
+    stock_payload: dict[str, Any] | None,
+    compare_entry: dict[str, Any] | None,
+    source: str,
+) -> pd.DataFrame:
+    trend_history = (compare_entry or {}).get("trend_history") or []
+    daily_trend = (stock_payload or {}).get("daily_trend") or []
+
+    rows: dict[str, dict[str, Any]] = {}
+
+    for point in trend_history:
+        date = point.get("date")
+        if not date:
+            continue
+        rows[date] = {
+            "timestamp": date,
+            "adanos_source": source,
+            "adanos_buzz_score": _safe_float(point.get("buzz_score")),
+            "adanos_mentions": 0,
+            "adanos_sentiment_score": 0.0,
+            "adanos_bullish_pct": _safe_float((compare_entry or {}).get("bullish_pct")),
+            "adanos_bearish_pct": _safe_float((compare_entry or {}).get("bearish_pct")),
+            "adanos_trend": (compare_entry or {}).get("trend", "stable"),
+            "adanos_latest_buzz_score": _safe_float((compare_entry or {}).get("buzz_score")),
+            "adanos_latest_sentiment_score": _safe_float((compare_entry or {}).get("sentiment_score")),
+        }
+
+    for point in daily_trend:
+        date = point.get("date")
+        if not date:
+            continue
+        row = rows.setdefault(
+            date,
+            {
+                "timestamp": date,
+                "adanos_source": source,
+                "adanos_buzz_score": _safe_float((compare_entry or {}).get("buzz_score")),
+                "adanos_mentions": 0,
+                "adanos_sentiment_score": 0.0,
+                "adanos_bullish_pct": _safe_float((compare_entry or {}).get("bullish_pct")),
+                "adanos_bearish_pct": _safe_float((compare_entry or {}).get("bearish_pct")),
+                "adanos_trend": (compare_entry or {}).get("trend", "stable"),
+                "adanos_latest_buzz_score": _safe_float((compare_entry or {}).get("buzz_score")),
+                "adanos_latest_sentiment_score": _safe_float((compare_entry or {}).get("sentiment_score")),
+            },
+        )
+        row["adanos_mentions"] = _safe_int(point.get("mentions"))
+        row["adanos_sentiment_score"] = _safe_float(point.get("sentiment_score"))
+
+    if not rows:
+        return pd.DataFrame(
+            columns=[
+                "timestamp",
+                "adanos_source",
+                "adanos_buzz_score",
+                "adanos_mentions",
+                "adanos_sentiment_score",
+                "adanos_bullish_pct",
+                "adanos_bearish_pct",
+                "adanos_trend",
+                "adanos_latest_buzz_score",
+                "adanos_latest_sentiment_score",
+            ]
+        )
+
+    frame = pd.DataFrame(rows.values())
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"]).dt.strftime("%Y-%m-%d")
+    frame = frame.sort_values(["timestamp", "adanos_source"]).reset_index(drop=True)
+    return frame
+
+
+@DOWNLOADER.register_module(force=True)
+class AdanosSentimentDownloader(Downloader):
+    def __init__(
+        self,
+        root: str = "",
+        token: str = None,
+        base_url: str = "https://api.adanos.org",
+        delay: float = 0.5,
+        start_date: str = "2023-04-01",
+        end_date: str = None,
+        stocks_path: str = None,
+        workdir: str = "",
+        tag: str = "",
+        days: int = 30,
+        sources: list[str] | tuple[str, ...] | None = None,
+        timeout: int = 30,
+        **kwargs,
+    ):
+        self.root = root
+        self.token = token if token is not None else os.environ.get("ADANOS_API_KEY")
+        self.base_url = base_url.rstrip("/")
+        self.delay = delay
+        self.start_date = start_date
+        self.end_date = end_date
+        self.stocks_path = os.path.join(root, stocks_path)
+        self.tag = tag
+        self.workdir = os.path.join(root, workdir, tag)
+        self.days = days
+        self.sources = tuple(sources or ADANOS_SOURCES)
+        self.timeout = timeout
+        self.log_path = os.path.join(self.workdir, f"{tag}.txt")
+
+        os.makedirs(self.workdir, exist_ok=True)
+        with open(self.log_path, "w") as op:
+            op.write("")
+
+        self.stocks = self._init_stocks()
+        super().__init__(**kwargs)
+
+    def _init_stocks(self):
+        with open(self.stocks_path) as op:
+            stocks = [line.strip() for line in op.readlines()]
+        return stocks
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self.token:
+            headers["X-API-Key"] = self.token
+        return headers
+
+    def _fetch_json(self, path: str, params: dict[str, Any]) -> Any:
+        response = requests.get(
+            url=f"{self.base_url}{path}",
+            headers=self._headers(),
+            params=params,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _download_source_frame(self, stock: str, source: str) -> pd.DataFrame:
+        compare_payload = self._fetch_json(
+            path=f"/{source}/stocks/v1/compare",
+            params={"tickers": stock, "days": self.days},
+        )
+        stock_payload = self._fetch_json(
+            path=f"/{source}/stocks/v1/stock/{stock}",
+            params={"days": self.days},
+        )
+
+        compare_entry = None
+        if isinstance(compare_payload, list) and compare_payload:
+            compare_entry = compare_payload[0]
+
+        return build_adanos_sentiment_frame(
+            stock_payload=stock_payload if isinstance(stock_payload, dict) else None,
+            compare_entry=compare_entry if isinstance(compare_entry, dict) else None,
+            source=source,
+        )
+
+    def download(self, stocks=None, start_date=None, end_date=None):
+        if not self.token:
+            raise ValueError("ADANOS_API_KEY is required to download Adanos sentiment data.")
+
+        stocks = stocks if stocks else self.stocks
+        start_bound = pd.to_datetime(start_date or self.start_date) if (start_date or self.start_date) else None
+        end_bound = pd.to_datetime(end_date or self.end_date) if (end_date or self.end_date) else None
+
+        for stock in stocks:
+            frames = []
+            for source in self.sources:
+                try:
+                    time.sleep(self.delay)
+                    frame = self._download_source_frame(stock=stock, source=source)
+                except Exception as exc:
+                    with open(self.log_path, "a") as op:
+                        op.write(f"{stock},{source},{exc}\n")
+                    continue
+
+                if frame.empty:
+                    continue
+                frames.append(frame)
+
+            if not frames:
+                continue
+
+            output = pd.concat(frames, axis=0, ignore_index=True)
+            output["timestamp"] = pd.to_datetime(output["timestamp"])
+            if start_bound is not None:
+                output = output[output["timestamp"] >= start_bound]
+            if end_bound is not None:
+                output = output[output["timestamp"] < end_bound]
+
+            output = output.sort_values(["timestamp", "adanos_source"]).reset_index(drop=True)
+            output["timestamp"] = output["timestamp"].dt.strftime("%Y-%m-%d")
+            output.to_csv(os.path.join(self.workdir, f"{stock}.csv"), index=False)

--- a/finagent/processor/processor.py
+++ b/finagent/processor/processor.py
@@ -58,6 +58,19 @@ def cal_sentiment(df, columns):
     return df
 
 
+ADANOS_SENTIMENT_COLUMNS = [
+    "adanos_source",
+    "adanos_buzz_score",
+    "adanos_mentions",
+    "adanos_sentiment_score",
+    "adanos_bullish_pct",
+    "adanos_bearish_pct",
+    "adanos_trend",
+    "adanos_latest_buzz_score",
+    "adanos_latest_sentiment_score",
+]
+
+
 def cal_factor(df, level="day"):
     # intermediate values
     df['max_oc'] = df[["open", "close"]].max(axis=1)
@@ -509,23 +522,28 @@ class Processor():
 
                 if sentiment_type == "fmp":
                     sentiment_column_map = {}
+                    selected_columns = sentiment_columns
+                elif sentiment_type == "adanos":
+                    sentiment_column_map = {}
+                    selected_columns = ADANOS_SENTIMENT_COLUMNS
+                else:
+                    raise ValueError("Unsupported sentiment_type: {}".format(sentiment_type))
 
                 assert os.path.exists(sentiment_path), "sentiment path {} does not exist".format(sentiment_path)
 
                 sentiment_df = pd.read_csv(sentiment_path)
-                sentiment_df = sentiment_df.rename(columns=sentiment_column_map)[["timestamp"] + sentiment_columns]
+                sentiment_df = sentiment_df.rename(columns=sentiment_column_map)[["timestamp"] + selected_columns]
                 sentiment_df["timestamp"] = pd.to_datetime(sentiment_df["timestamp"])
 
                 sentiment_df = sentiment_df[ (sentiment_df["timestamp"] >= start_date) & (sentiment_df["timestamp"] < end_date)]
                 sentiment_df = sentiment_df.sort_values(by="timestamp")
                 sentiment_df["timestamp"] = pd.to_datetime(sentiment_df["timestamp"]).apply(lambda x: x.strftime("%Y-%m-%d"))
 
-                if sentiment_type == "rapidapi_seekingalpha":
-                    sentiment_df["type"] = "rapidapi"
-                    sentiment_df["source"] = "seekingalpha"
-
-                sentiment_df = cal_sentiment(sentiment_df, sentiment_columns)
-                sentiment_df = sentiment_df.drop_duplicates(subset=["timestamp"], keep="first")
+                if sentiment_type == "adanos":
+                    sentiment_df = sentiment_df.drop_duplicates(subset=["timestamp", "adanos_source"], keep="last")
+                else:
+                    sentiment_df = cal_sentiment(sentiment_df, sentiment_columns)
+                    sentiment_df = sentiment_df.drop_duplicates(subset=["timestamp"], keep="first")
                 sentiment_df = sentiment_df.reset_index(drop=True)
                 sentiment_df["timestamp"] = pd.to_datetime(sentiment_df["timestamp"]).apply(lambda x: x.strftime("%Y-%m-%d"))
                 sentiments_df.append(sentiment_df)
@@ -545,7 +563,10 @@ class Processor():
 
             sentiments_df = sentiments_df.sort_values(by="timestamp")
             sentiments_df = sentiments_df.reset_index(drop=True)
-            sentiments_df = sentiments_df[["timestamp", "type"] + sentiment_columns]
+            if "adanos_source" in sentiments_df.columns:
+                sentiments_df = sentiments_df[["timestamp", "type"] + ADANOS_SENTIMENT_COLUMNS]
+            else:
+                sentiments_df = sentiments_df[["timestamp", "type"] + sentiment_columns]
 
             outpath = os.path.join(self.root, self.workdir, self.tag, "sentiment")
             os.makedirs(outpath, exist_ok=True)

--- a/finagent/prompt/helper.py
+++ b/finagent/prompt/helper.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 ROOT = str(Path(__file__).resolve().parents[2])
 import warnings
+from finagent.prompt.sentiment import format_social_sentiment_text
 def str2html(doc: str) -> BeautifulSoup:
     doc = BeautifulSoup(doc, 'html.parser')
     return doc
@@ -143,8 +144,7 @@ def prepared_tools_params(state: Dict,
                 guidance_text = "\n".join(guidance_list)
 
     # prepare sentiment
-    # TODO: add sentiment for social media
-    sentiment_text = None
+    sentiment_text = format_social_sentiment_text(sentiment=sentiment, date=date)
 
     # prepare stategies
 

--- a/finagent/prompt/sentiment.py
+++ b/finagent/prompt/sentiment.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+ADANOS_SENTIMENT_COLUMNS = [
+    "adanos_source",
+    "adanos_buzz_score",
+    "adanos_mentions",
+    "adanos_sentiment_score",
+    "adanos_bullish_pct",
+    "adanos_bearish_pct",
+    "adanos_trend",
+    "adanos_latest_buzz_score",
+    "adanos_latest_sentiment_score",
+]
+
+
+def format_social_sentiment_text(
+    sentiment: pd.DataFrame | None,
+    date: str,
+) -> str:
+    """Render the latest available social sentiment slice for prompt templates."""
+    if sentiment is None or sentiment.empty:
+        return "There is no social sentiment data today.\n"
+
+    frame = sentiment.copy()
+    if "timestamp" in frame.columns:
+        frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+    else:
+        frame = frame.copy()
+        frame.index = pd.to_datetime(frame.index)
+        frame["timestamp"] = frame.index
+
+    current_date = pd.to_datetime(date)
+    frame = frame[frame["timestamp"] <= current_date]
+
+    if frame.empty:
+        return "There is no social sentiment data today.\n"
+
+    latest_timestamp = frame["timestamp"].max()
+    latest_rows = frame[frame["timestamp"] == latest_timestamp].copy()
+
+    if "adanos_source" in latest_rows.columns:
+        summaries = []
+        for _, row in latest_rows.iterrows():
+            summaries.append(
+                "Adanos Social Sentiment\n"
+                f"Source: {row.get('adanos_source', 'unknown')}\n"
+                f"Date: {latest_timestamp.strftime('%Y-%m-%d')}\n"
+                f"Buzz Score: {row.get('adanos_latest_buzz_score', row.get('adanos_buzz_score', 'n/a'))}\n"
+                f"Sentiment Score: {row.get('adanos_latest_sentiment_score', row.get('adanos_sentiment_score', 'n/a'))}\n"
+                f"Bullish: {row.get('adanos_bullish_pct', 'n/a')}%\n"
+                f"Bearish: {row.get('adanos_bearish_pct', 'n/a')}%\n"
+                f"Mentions: {row.get('adanos_mentions', 'n/a')}\n"
+                f"Trend: {row.get('adanos_trend', 'n/a')}\n"
+            )
+        return "\n".join(summaries)
+
+    row = latest_rows.iloc[-1]
+    return (
+        "Social Sentiment\n"
+        f"Date: {latest_timestamp.strftime('%Y-%m-%d')}\n"
+        f"Stocktwits Posts: {row.get('stocktwits_posts', 'n/a')}\n"
+        f"Stocktwits Comments: {row.get('stocktwits_comments', 'n/a')}\n"
+        f"Stocktwits Likes: {row.get('stocktwits_likes', 'n/a')}\n"
+        f"Stocktwits Impressions: {row.get('stocktwits_impressions', 'n/a')}\n"
+        f"Stocktwits Sentiment: {row.get('stocktwits_sentiment', 'n/a')}\n"
+    )

--- a/unit_testing/test_finagent_adanos_sentiment.py
+++ b/unit_testing/test_finagent_adanos_sentiment.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, relative_path: str):
+    module_path = REPO_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_dataset_module():
+    finagent_pkg = types.ModuleType("finagent")
+    finagent_pkg.__path__ = []
+
+    data_pkg = types.ModuleType("finagent.data")
+    data_pkg.__path__ = []
+    data_pkg.BaseDataset = object
+
+    class _Registry:
+        def register_module(self, force=False):
+            def decorator(cls):
+                return cls
+
+            return decorator
+
+    registry_module = types.ModuleType("finagent.registry")
+    registry_module.DATASET = _Registry()
+
+    original_modules = {}
+    for name, module in {
+        "finagent": finagent_pkg,
+        "finagent.data": data_pkg,
+        "finagent.registry": registry_module,
+    }.items():
+        original_modules[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    try:
+        return _load_module("test_finagent_dataset", "finagent/data/dataset.py")
+    finally:
+        for name, previous in original_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+def _load_downloader_module():
+    finagent_pkg = types.ModuleType("finagent")
+    finagent_pkg.__path__ = []
+
+    downloader_pkg = types.ModuleType("finagent.downloader")
+    downloader_pkg.__path__ = []
+
+    custom_module = types.ModuleType("finagent.downloader.custom")
+    custom_module.Downloader = object
+
+    class _Registry:
+        def register_module(self, force=False):
+            def decorator(cls):
+                return cls
+
+            return decorator
+
+    registry_module = types.ModuleType("finagent.registry")
+    registry_module.DOWNLOADER = _Registry()
+
+    original_modules = {}
+    for name, module in {
+        "finagent": finagent_pkg,
+        "finagent.downloader": downloader_pkg,
+        "finagent.downloader.custom": custom_module,
+        "finagent.registry": registry_module,
+    }.items():
+        original_modules[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    try:
+        return _load_module(
+            "test_adanos_downloader",
+            "finagent/downloader/tools/adanos_sentiment_downloader.py",
+        )
+    finally:
+        for name, previous in original_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+def test_normalize_sentiment_dataframe_accepts_adanos_schema():
+    dataset_module = _load_dataset_module()
+    frame = pd.DataFrame(
+        [
+            {
+                "timestamp": "2026-04-28",
+                "adanos_source": "reddit",
+                "adanos_buzz_score": 74.3,
+                "adanos_mentions": 1784,
+                "adanos_sentiment_score": -0.03,
+                "adanos_bullish_pct": 28.0,
+                "adanos_bearish_pct": 19.0,
+                "adanos_trend": "falling",
+                "adanos_latest_buzz_score": 74.3,
+                "adanos_latest_sentiment_score": -0.03,
+                "extra": "ignored",
+            }
+        ]
+    )
+
+    normalized = dataset_module.normalize_sentiment_dataframe(frame)
+
+    assert list(normalized.columns) == dataset_module.ADANOS_SENTIMENT_COLUMNS
+    assert normalized.iloc[0]["adanos_source"] == "reddit"
+
+
+def test_build_adanos_sentiment_frame_merges_compare_and_daily_trend():
+    downloader_module = _load_downloader_module()
+
+    frame = downloader_module.build_adanos_sentiment_frame(
+        stock_payload={
+            "daily_trend": [
+                {"date": "2026-04-27", "mentions": 12, "sentiment_score": 0.35},
+                {"date": "2026-04-28", "mentions": 18, "sentiment_score": 0.41},
+            ]
+        },
+        compare_entry={
+            "buzz_score": 71.5,
+            "sentiment_score": 0.38,
+            "bullish_pct": 61.0,
+            "bearish_pct": 17.0,
+            "trend": "rising",
+            "trend_history": [
+                {"date": "2026-04-27", "buzz_score": 68.0},
+                {"date": "2026-04-28", "buzz_score": 71.5},
+            ],
+        },
+        source="reddit",
+    )
+
+    assert list(frame["timestamp"]) == ["2026-04-27", "2026-04-28"]
+    assert list(frame["adanos_mentions"]) == [12, 18]
+    assert list(frame["adanos_buzz_score"]) == [68.0, 71.5]
+    assert set(frame["adanos_trend"]) == {"rising"}
+    assert set(frame["adanos_source"]) == {"reddit"}
+
+
+def test_format_social_sentiment_text_renders_adanos_sources():
+    sentiment_module = _load_module("test_prompt_sentiment", "finagent/prompt/sentiment.py")
+    frame = pd.DataFrame(
+        [
+            {
+                "timestamp": "2026-04-28",
+                "adanos_source": "reddit",
+                "adanos_buzz_score": 74.3,
+                "adanos_mentions": 1784,
+                "adanos_sentiment_score": -0.03,
+                "adanos_bullish_pct": 28.0,
+                "adanos_bearish_pct": 19.0,
+                "adanos_trend": "falling",
+                "adanos_latest_buzz_score": 74.3,
+                "adanos_latest_sentiment_score": -0.03,
+            },
+            {
+                "timestamp": "2026-04-28",
+                "adanos_source": "news",
+                "adanos_buzz_score": 63.1,
+                "adanos_mentions": 94,
+                "adanos_sentiment_score": 0.12,
+                "adanos_bullish_pct": 52.0,
+                "adanos_bearish_pct": 13.0,
+                "adanos_trend": "stable",
+                "adanos_latest_buzz_score": 63.1,
+                "adanos_latest_sentiment_score": 0.12,
+            },
+        ]
+    )
+
+    text = sentiment_module.format_social_sentiment_text(frame, "2026-04-28")
+
+    assert "Source: reddit" in text
+    assert "Source: news" in text
+    assert "Trend: falling" in text
+    assert "Mentions: 1784" in text


### PR DESCRIPTION
## Summary
- add an optional `AdanosSentimentDownloader` for FinAgent stock experiments
- support Adanos sentiment parquet schemas in the dataset / processor / prompt flow
- add README notes, config example, and focused unit tests

## Why
TradeMaster's `finagent` stack already supports an optional `sentiment_path`, but the current path is effectively tied to FMP/Stocktwits-style data. This PR adds a second, fully optional path for cross-source stock sentiment from Reddit, X, News, and Polymarket via the Adanos Market Sentiment API.

The integration is intentionally non-invasive:
- existing FMP sentiment configs continue to work unchanged
- Adanos is only used if a user explicitly configures the new downloader and provides `ADANOS_API_KEY`
- prompt generation now renders available social sentiment instead of leaving the social sentiment slot empty

## Validation
- `python3 -m pytest unit_testing/test_finagent_adanos_sentiment.py -q`
- `python3 -m py_compile finagent/downloader/tools/adanos_sentiment_downloader.py finagent/processor/processor.py finagent/data/dataset.py finagent/prompt/sentiment.py unit_testing/test_finagent_adanos_sentiment.py`
- `git diff --check`
